### PR TITLE
Added target-postgres meltano variant support, Made tap single customer_id sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # tap-googleads
 
+This fork of `tap-googleads` supports the meltano varient of `target-postgres` and will sync ONLY the GoogleAds data under your specified `customer_id`.
+
 `tap-googleads` is a Singer tap for GoogleAds.
 
-THIS IS NOT READY FOR PRODUCTION. Bearer tokens sometimes slip out to logs. Use at your own Peril :D
-
+Bearer tokens sometimes slip out to logs. Use at your own Peril :D
 
 Built with the [Meltano Tap SDK](https://sdk.meltano.com) for Singer Taps.
 


### PR DESCRIPTION
- Updated the tap so it works with the meltano variant of `target-postgres`
Psycopg2 errors caused by having primary keys in the streams, meant removing them for the time being.

- Updated the tap so the child and parent stream structure still exists but will only sync your specified `customer_id`
This fixes a target-postgres problem with the child parent streams where each time a child stream was used, it re-created the table in the database removing all previous data. This cause you to only have the data in your database about the last `customer_id`synced and none of the previous.