### PR TITLE
Fix/put all oauth creds under oauth credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ pipx install tap-googleads
 
 Settings required to run this tap.
 
-- `client_id` (required)
-- `client_secret` (required)
+- `oauth_credentials.client_id` (required)
+- `oauth_credentials.client_secret` (required)
+- `oauth_credentials.refresh_token` (required)
 - `developer_token` (required)
-- `refresh_token` (required)
 - `customer_id` (required)
 - `start_date` (optional)
 - `end_date` (optional)

--- a/meltano.yml
+++ b/meltano.yml
@@ -11,13 +11,7 @@ plugins:
     - catalog
     - discover
     settings:
-    - name: client_id
-      kind: password
-    - name: client_secret
-      kind: password
     - name: developer_token
-      kind: password
-    - name: refresh_token
       kind: password
     - name: customer_id
       kind: password
@@ -50,7 +44,6 @@ plugins:
       - OAUTH_CREDENTIALS_ACCESS_TOKEN
       kind: hidden
       label: Optional - OAuth Access Token for use with a proxy refresh server
-      required: false
     - name: oauth_credentials.refresh_token
       env_aliases:
       - OAUTH_CREDENTIALS_REFRESH_TOKEN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-googleads"
-version = "0.1.0"
+version = "0.1.1"
 description = "`tap-googleads` is a Singer tap for GoogleAds, built with the Meltano SDK for Singer Taps."
 authors = ["AutoIDM", "Matatika"]
 keywords = [

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -40,17 +40,24 @@ class GoogleAdsStream(RESTStream):
         """Return a new authenticator object."""
         base_auth_url = "https://www.googleapis.com/oauth2/v4/token"
         # Silly way to do parameters but it works
-        auth_url = (
-            base_auth_url + f"?refresh_token={self.config.get('refresh_token', None)}"
+
+        client_id = self.config.get("oauth_credentials", {}).get("client_id", None)
+        client_secret = self.config.get("oauth_credentials", {}).get(
+            "client_secret", None
         )
-        auth_url = auth_url + f"&client_id={self.config.get('client_id')}"
-        auth_url = auth_url + f"&client_secret={self.config.get('client_secret')}"
+        refresh_token = self.config.get("oauth_credentials", {}).get(
+            "refresh_token", None
+        )
+
+        auth_url = base_auth_url + f"?refresh_token={refresh_token}"
+        auth_url = auth_url + f"&client_id={client_id}"
+        auth_url = auth_url + f"&client_secret={client_secret}"
         auth_url = auth_url + "&grant_type=refresh_token"
 
-        oauth_credentials = self.config.get("oauth_credentials", {})
-
-        if not oauth_credentials:
+        if client_id and client_secret and refresh_token:
             return GoogleAdsAuthenticator(stream=self, auth_endpoint=auth_url)
+
+        oauth_credentials = self.config.get("oauth_credentials", {})
 
         auth_body = {}
         auth_headers = {}

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -42,11 +42,11 @@ class TapGoogleAds(Tap):
     # TODO: Add Descriptions
     config_jsonschema = th.PropertiesList(
         th.Property(
-            "client_id",
+            "oauth_credentials.client_id",
             th.StringType,
         ),
         th.Property(
-            "client_secret",
+            "oauth_credentials.client_secret",
             th.StringType,
         ),
         th.Property(
@@ -54,7 +54,7 @@ class TapGoogleAds(Tap):
             th.StringType,
         ),
         th.Property(
-            "refresh_token",
+            "oauth_credentials.refresh_token",
             th.StringType,
         ),
         th.Property(


### PR DESCRIPTION
- Updated all references to client_id, client_secret and refresh_token to be "under"  oauth_credentials (like the other settings).
- Minor README update to reflect changed settings names.
- Bumped version to 0.1.1