### PR TITLE
Stream for User geo data (location of presence)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-googleads"
-version = "0.3.2"
+version = "0.3.3"
 description = "`tap-googleads` is a Singer tap for GoogleAds, built with the Meltano SDK for Singer Taps."
 authors = ["AutoIDM", "Matatika"]
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-googleads"
-version = "0.3.3"
+version = "0.3.4"
 description = "`tap-googleads` is a Singer tap for GoogleAds, built with the Meltano SDK for Singer Taps."
 authors = ["AutoIDM", "Matatika"]
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-googleads"
-version = "0.3.4"
+version = "0.3.5"
 description = "`tap-googleads` is a Singer tap for GoogleAds, built with the Meltano SDK for Singer Taps."
 authors = ["AutoIDM", "Matatika"]
 keywords = [

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -31,7 +31,7 @@ class GoogleAdsStream(RESTStream):
     _LOG_REQUEST_METRIC_URLS: bool = True
 
     _end_date = "'" + datetime.now().strftime("%Y-%m-%d") + "'"
-    _start_date = datetime.now() - timedelta(days=365)
+    _start_date = datetime.now() - timedelta(days=91)
     _start_date = "'" + _start_date.strftime("%Y-%m-%d") + "'"
 
     @property

--- a/tap_googleads/schemas/geo_performance.json
+++ b/tap_googleads/schemas/geo_performance.json
@@ -1,0 +1,50 @@
+{
+  "type": "object",
+  "properties": {
+    "customer_id": {
+      "type": "string"
+    },
+    "campaign": {
+      "type": "object",
+      "properties": {
+        "resourceName": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        }
+      }
+    },
+    "metrics": {
+      "type": "object",
+      "properties": {
+        "clicks": {
+          "type": "string"
+        },
+        "costMicros": {
+          "type": "string"
+        },
+        "impressions": {
+          "type": "string"
+        },
+        "conversions": {
+          "type": "number"
+        }
+      }
+    },
+    "geographicView": {
+      "type": "object",
+      "properties": {
+        "locationType": {
+          "type": "string"
+        },
+        "countryCriterionId": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/tap_googleads/schemas/geo_performance.json
+++ b/tap_googleads/schemas/geo_performance.json
@@ -35,6 +35,14 @@
         }
       }
     },
+    "segments": {
+      "type": "object",
+      "properties": {
+        "date": {
+          "type": "string"
+        }
+      }
+    },
     "geographicView": {
       "type": "object",
       "properties": {

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -110,7 +110,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        return {"client_id": self.config.get("customer_id")}
+        return {"customer_id": self.config.get("customer_id")}
 
 
 class GeotargetsStream(GoogleAdsStream):
@@ -342,8 +342,9 @@ class GeoPerformance(ReportsStream):
     name = "geo_performance"
     primary_keys = [
         "geographic_view__country_criterion_id",
+        "customer_id",
         "campaign__name",
-        "segments__date",
+        "segments__date"
     ]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "geo_performance.json"

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -317,3 +317,33 @@ class CampaignPerformanceByLocation(ReportsStream):
     ]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "campaign_performance_by_location.json"
+
+class GeoPerformance(ReportsStream):
+    """Geo performance"""
+
+    @property
+    def gaql(self):
+        return f"""
+    SELECT 
+        campaign.name, 
+        campaign.status, 
+        segments.date, 
+        metrics.clicks, 
+        metrics.cost_micros,
+        metrics.impressions, 
+        metrics.conversions,
+        geographic_view.location_type,
+        geographic_view.country_criterion_id
+    FROM geographic_view 
+    WHERE segments.date >= {self.start_date} and segments.date <= {self.end_date} 
+    """
+
+    records_jsonpath = "$.results[*]"
+    name = "geo_performance"
+    primary_keys = [
+        "geographic_view__country_criterion_id",
+        "campaign__name",
+        "segments__date",
+    ]
+    replication_key = None
+    schema_filepath = SCHEMAS_DIR / "geo_performance.json"

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -16,6 +16,7 @@ from tap_googleads.streams import (
     CampaignPerformanceByGenderAndDevice,
     CampaignPerformanceByLocation,
     GeotargetsStream,
+    GeoPerformance
 )
 
 STREAM_TYPES = [
@@ -29,6 +30,7 @@ STREAM_TYPES = [
     CampaignPerformanceByGenderAndDevice,
     CampaignPerformanceByLocation,
     GeotargetsStream,
+    GeoPerformance
 ]
 
 

--- a/tap_googleads/tests/test_base_credentials.py
+++ b/tap_googleads/tests/test_base_credentials.py
@@ -33,7 +33,7 @@ class TestTapGoogleadsWithBaseCredentials(unittest.TestCase):
         catalog = TapGoogleAds(self.mock_config).discover_streams()
 
         # expect valid catalog to be discovered
-        self.assertEqual(len(catalog), 10, "Total streams from default catalog")
+        self.assertEqual(len(catalog), 11, "Total streams from default catalog")
 
     @responses.activate
     def test_googleads_sync_accessible_customers(self):

--- a/tap_googleads/tests/test_proxy_oauth.py
+++ b/tap_googleads/tests/test_proxy_oauth.py
@@ -32,7 +32,7 @@ class TestTapGoogleadsWithProxyOAuthCredentials(unittest.TestCase):
         catalog = TapGoogleAds(self.mock_config).discover_streams()
 
         # Assert the correct number of default streams found
-        self.assertEqual(len(catalog), 10, "Total streams from default catalog")
+        self.assertEqual(len(catalog), 11, "Total streams from default catalog")
 
     @responses.activate
     def test_proxy_oauth_refresh(self):


### PR DESCRIPTION
Summary
We needed to get the campaign performance broken down by user location. Current streams don't have it so we've created a new one for this purpose. Some other bug fixes and small enhancements were done along the road

Details
- Created a new stream geo_performance
- Fixed `customer_id`. It was missing from the output as the name in the code and the name in the JSON schema were different
- Changed the default pull period from 365 to 90 days. Normally the initial data extract is done just once and it can cover more than one year but after that, we need only the data that can be changed by google within the conversion window. Its maximum value is 90. It's much easier to omit the `start` and `stop` dates in the config and have such a behavior by default rather than always dynamically changing the `start date`.