### PR TITLE
Bump the singer-sdk version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,9 +10,9 @@ keywords = [
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "<3.10,>=3.6.2"
+python = "<3.12,>=3.7.0"
 requests = "^2.25.1"
-singer-sdk = "0.3.12"
+singer-sdk = "0.18.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-googleads"
-version = "0.3.3"
+version = "0.4.0"
 description = "`tap-googleads` is a Singer tap for GoogleAds, built with the Meltano SDK for Singer Taps."
 authors = ["AutoIDM", "Matatika"]
 keywords = [


### PR DESCRIPTION
- Bumped the `singer-sdk` version to `0.18.0`
- Changed supported python versions to `3.7` to `3.11`
- Bumped tap version to `0.4.0`