### PR TITLE
Add login_customer_id config

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,11 @@ Settings required to run this tap.
 - `oauth_credentials.refresh_token` (required)
 - `developer_token` (required)
 - `customer_id` (required)
+- `login_customer_id` (optional)
 - `start_date` (optional)
 - `end_date` (optional)
+
+If using a manager account, `login_customer_id` should be set to the customer ID of the manager account while `customer_id` should be set to the customer ID of the account you want to sync.
 
 How to get these settings can be found in the following Google Ads documentation:
 

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -75,7 +75,7 @@ class GoogleAdsStream(RESTStream):
         if "user_agent" in self.config:
             headers["User-Agent"] = self.config.get("user_agent")
         headers["developer-token"] = self.config["developer_token"]
-        headers["login-customer-id"] = self.config["customer_id"]
+        headers["login-customer-id"] = self.config.get("login_customer_id", self.config["customer_id"])
         return headers
 
     def get_next_page_token(

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -61,6 +61,11 @@ class TapGoogleAds(Tap):
             "customer_id",
             th.StringType,
         ),
+        th.Property(
+            "login_customer_id",
+            th.StringType,
+            description="Value to use in the login-customer-id header, if different from the customer_id to sync. Useful if you are syncing using a manager account.",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:


### PR DESCRIPTION
Setting the value of the `login-customer-id` header to the same value as the syncing `customer_id` prevents using this tap with a manager account.

This PR makes the `login-customer-id` header a separate and optional config property (`login_customer_id`) so manager accounts can be used. If not specified, the `login-customer-id` header will still be set to the configured `customer_id`.