### PR TITLE
Adding conversion and Ad Groups Historical Performance stream

### DIFF
--- a/tap_googleads/schemas/adgropus_historical_performance.json
+++ b/tap_googleads/schemas/adgropus_historical_performance.json
@@ -1,0 +1,55 @@
+{
+    "type": "object",
+    "properties": {
+                "customer_id": {
+                    "type": "string"
+                },
+        "campaign": {
+            "type": "object",
+            "properties": {
+                "resourceName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "adGroup": {
+            "type": "object",
+            "properties": {
+                "resourceName": {
+                    "type": "string"
+                },
+                "id": {
+                    "type": "string"
+                },
+                "status": {
+                    "type": "string"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "clicks": {
+                    "type": "string"
+                },
+                "costMicros": {
+                    "type": "string"
+                },
+                "impressions": {
+                    "type": "string"
+                }
+            }
+        },
+        "segments": {
+            "type": "object",
+            "properties": {
+                "date": {
+                    "type": "string"
+                }
+            }
+        }
+    }
+}

--- a/tap_googleads/schemas/conversion.json
+++ b/tap_googleads/schemas/conversion.json
@@ -1,0 +1,84 @@
+{
+    "type": "object",
+    "properties": {
+        "metrics": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "allConversionsValue": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                },
+                "allConversions": {
+                    "type": [
+                        "integer",
+                        "null"
+                    ]
+                }
+            }
+        },
+        "segments": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "date": {
+                    "type": [
+                        "string",
+                        "null"
+                    ],
+                    "format": "date"
+                }
+            }
+        },
+        "conversionAction": {
+            "type": [
+                "object",
+                "null"
+            ],
+            "properties": {
+                "resourceName": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "category": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "id": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "name": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "ownerCustomer": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                },
+                "origin": {
+                    "type": [
+                        "string",
+                        "null"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -347,3 +347,31 @@ class GeoPerformance(ReportsStream):
     ]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "geo_performance.json"
+
+class Conversion(ReportsStream):
+    """Conversion"""
+
+    @property
+    def gaql(self):
+        return f"""
+    SELECT 
+        segments.date,
+        conversion_action.id,
+        conversion_action.name,
+        conversion_action.category,
+        conversion_action.origin,
+        conversion_action.owner_customer,
+        metrics.all_conversions,
+        metrics.all_conversions_value
+    FROM conversion_action
+    WHERE segments.date >= {self.start_date} and segments.date <= {self.end_date} 
+    """
+
+    records_jsonpath = "$.results[*]"
+    name = "stream_conversion"
+    primary_keys = [
+        "conversion_action__id",
+        "segments__date"
+    ]
+    replication_key = None
+    schema_filepath = SCHEMAS_DIR / "conversion.json"

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -231,6 +231,25 @@ class AdGroupsPerformance(ReportsStream):
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "adgroups_performance.json"
 
+class AdGroupsHistoricalPerformance(ReportsStream):
+    """AdGroups Performance"""
+
+    @property
+    def gaql(self):
+        return f"""
+        SELECT campaign.id, ad_group.id, ad_group.status, segments.date, metrics.impressions, metrics.clicks,
+               metrics.cost_micros
+               FROM ad_group
+               WHERE segments.date >= {self.start_date} and segments.date <= {self.end_date}
+        """
+
+    records_jsonpath = "$.results[*]"
+    name = "stream_adgroupshistoricalperformance"
+    primary_keys = ["campaign__id", "ad_group__id", "segments__date", ]
+    replication_key = None
+    schema_filepath = SCHEMAS_DIR / "adgroups_historical_performance.json"
+
+
 
 class CampaignPerformance(ReportsStream):
     """Campaign Performance"""

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -8,6 +8,7 @@ from singer_sdk import typing as th  # JSON schema typing helpers
 from tap_googleads.streams import (
     AccessibleCustomers,
     AdGroupsPerformance,
+    AdGroupsHistoricalPerformance,
     AdGroupsStream,
     CampaignPerformance,
     CampaignPerformanceByAgeRangeAndDevice,
@@ -24,6 +25,7 @@ STREAM_TYPES = [
     CampaignsStream,
     AdGroupsStream,
     AdGroupsPerformance,
+    AdGroupsHistoricalPerformance,
     AccessibleCustomers,
     CustomerHierarchyStream,
     CampaignPerformance,

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -17,6 +17,7 @@ from tap_googleads.streams import (
     CustomerHierarchyStream,
     GeoPerformance,
     GeotargetsStream,
+    Conversion,
 )
 
 STREAM_TYPES = [
@@ -31,6 +32,7 @@ STREAM_TYPES = [
     CampaignPerformanceByLocation,
     GeotargetsStream,
     GeoPerformance,
+    Conversion,
 ]
 
 


### PR DESCRIPTION
Couple of extra streams I found useful:

- Conversion metrics (count of conversions by conversion id and date).
- Ad Group Historical performance (same as Ad group but addition of date segment to query, allows you to aggregate up from this lowest grain of data).