### PR TITLE
Feature - New array of customer ids setting & New Click View Report Stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,12 @@ Settings required to run this tap.
 - `login_customer_id` (optional)
 - `start_date` (optional)
 - `end_date` (optional)
+- `comma_separated_string_of_customer_ids` (optional) String of comma separated ids: `123, 456, 789`
+- `enable_click_view_report_stream` (optional) Boolean, Default is `False`
 
 If using a manager account, `login_customer_id` should be set to the customer ID of the manager account while `customer_id` should be set to the customer ID of the account you want to sync.
+
+If you provide `comma_separated_string_of_customer_ids`, you are overriding what customer_id(s) to get data for.
 
 How to get these settings can be found in the following Google Ads documentation:
 

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -75,7 +75,7 @@ class GoogleAdsStream(RESTStream):
         if "user_agent" in self.config:
             headers["User-Agent"] = self.config.get("user_agent")
         headers["developer-token"] = self.config["developer_token"]
-        headers["login-customer-id"] = self.config.get("login_customer_id", self.config["customer_id"])
+        headers["login-customer-id"] = self.config.get("login_customer_id", self.config.get("customer_id"))
         return headers
 
     def get_next_page_token(

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -75,7 +75,7 @@ class GoogleAdsStream(RESTStream):
         if "user_agent" in self.config:
             headers["User-Agent"] = self.config.get("user_agent")
         headers["developer-token"] = self.config["developer_token"]
-        headers["login-customer-id"] = self.config.get("login_customer_id", self.config.get("customer_id"))
+        headers["login-customer-id"] = self.config.get("login_customer_id")
         return headers
 
     def get_next_page_token(

--- a/tap_googleads/schemas/click_view_report.json
+++ b/tap_googleads/schemas/click_view_report.json
@@ -1,0 +1,87 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "click_view": {
+            "type": "object",
+            "properties": {
+                "gclid": {
+                    "type": "string"
+                },
+                "ad_group_ad": {
+                    "type": "string"
+                },
+                "keyword": {
+                    "type": "string"
+                },
+                "keyword_info": {
+                    "type": "object",
+                    "properties": {
+                        "match_type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "customer": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                }
+            }
+        },
+        "ad_group": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "campaign": {
+            "type": "object",
+            "properties": {
+                "id": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "segments": {
+            "type": "object",
+            "properties": {
+                "ad_network_type": {
+                    "type": "string"
+                },
+                "device": {
+                    "type": "string"
+                },
+                "date": {
+                    "type": "string",
+                    "format": "date"
+                },
+                "slot": {
+                    "type": "string"
+                },
+                "click_type": {
+                    "type": "string"
+                }
+            }
+        },
+        "metrics": {
+            "type": "object",
+            "properties": {
+                "clicks": {
+                    "type": "integer"
+                }
+            }
+        }
+    }
+}

--- a/tap_googleads/schemas/click_view_report.json
+++ b/tap_googleads/schemas/click_view_report.json
@@ -2,22 +2,22 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
-        "click_view": {
+        "clickView": {
             "type": "object",
             "properties": {
                 "gclid": {
                     "type": "string"
                 },
-                "ad_group_ad": {
+                "adGroupAd": {
                     "type": "string"
                 },
                 "keyword": {
                     "type": "string"
                 },
-                "keyword_info": {
+                "keywordInfo": {
                     "type": "object",
                     "properties": {
-                        "match_type": {
+                        "matchType": {
                             "type": "string"
                         }
                     }
@@ -32,7 +32,7 @@
                 }
             }
         },
-        "ad_group": {
+        "adGroup": {
             "type": "object",
             "properties": {
                 "id": {
@@ -57,7 +57,7 @@
         "segments": {
             "type": "object",
             "properties": {
-                "ad_network_type": {
+                "adNetworkType": {
                     "type": "string"
                 },
                 "device": {

--- a/tap_googleads/schemas/click_view_report.json
+++ b/tap_googleads/schemas/click_view_report.json
@@ -54,6 +54,10 @@
                 }
             }
         },
+        "date": {
+            "type": "string",
+            "format": "date"
+        },
         "segments": {
             "type": "object",
             "properties": {
@@ -63,14 +67,10 @@
                 "device": {
                     "type": "string"
                 },
-                "date": {
-                    "type": "string",
-                    "format": "date"
-                },
                 "slot": {
                     "type": "string"
                 },
-                "click_type": {
+                "clickType": {
                     "type": "string"
                 }
             }

--- a/tap_googleads/schemas/click_view_report.json
+++ b/tap_googleads/schemas/click_view_report.json
@@ -79,7 +79,7 @@
             "type": "object",
             "properties": {
                 "clicks": {
-                    "type": "integer"
+                    "type": "string"
                 }
             }
         }

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -248,10 +248,11 @@ class ClickViewReportStream(ReportsStream):
         else:
             last_replication_date = None
 
+        yesterdays_date = datetime.now() - timedelta(days=1)
+
         # if last_replication_date is today or greater, set the date to yesterday (last full days data)
         if last_replication_date:
             if last_replication_date >= datetime.now().strftime("%Y-%m-%d"):
-                yesterdays_date = datetime.now() - timedelta(days=1)
                 last_replication_date = yesterdays_date.strftime("%Y-%m-%d")
 
             # This is if the last_replication_date defaults back to the start date (timestamp)

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -103,7 +103,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
             customer_id_array = self.config.get("array_of_customer_ids")
             #customer_id_array = self.config.get("array_of_customer_ids").replace('[', '').replace(']', '').replace(' ', '').split(',')
             for i in customer_id_array:
-                yield {"customerClient": {"id": i}}
+                yield {"customerClient": {"id": str(i)}}
         else:
             for row in self.request_records(context):
                 row = self.post_process(row, context)
@@ -186,7 +186,19 @@ class ClickViewReportStream(ReportsStream):
 
     records_jsonpath = "$.results[*]"
     name = "stream_click_view_report"
-    primary_keys = ["click_view__gclid"]
+    primary_keys = [
+        "click_view__gclid",
+        "click_view__ad_group_ad",
+        "click_view__keyword",
+        "click_view__keyword_info__match_type",
+        "customer__id",
+        "ad_group__id",
+        "campaign__id",
+        "segments__device",
+        "segments__ad_network_type",
+        "segments__slot",
+        "segments__date"
+    ]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "click_view_report.json"
 

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -99,13 +99,18 @@ class CustomerHierarchyStream(GoogleAdsStream):
         Yields:
             One item per (possibly processed) record in the API.
         """
-
-        for row in self.request_records(context):
-            row = self.post_process(row, context)
-            # Don't search Manager accounts as we can't query them for everything
-            if row["customerClient"]["manager"] == True:
-                continue
-            yield row
+        if self.config.get("array_of_customer_ids", False):
+            customer_id_array = self.config.get("array_of_customer_ids")
+            #customer_id_array = self.config.get("array_of_customer_ids").replace('[', '').replace(']', '').replace(' ', '').split(',')
+            for i in customer_id_array:
+                yield {"customerClient": {"id": i}}
+        else:
+            for row in self.request_records(context):
+                row = self.post_process(row, context)
+                # Don't search Manager accounts as we can't query them for everything
+                if row["customerClient"]["manager"] == True:
+                    continue
+                yield row
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -100,8 +100,9 @@ class CustomerHierarchyStream(GoogleAdsStream):
         Yields:
             One item per (possibly processed) record in the API.
         """
-        if self.config.get("array_of_customer_ids", False):
-            for i in self.config.get("array_of_customer_ids"):
+        if self.config.get("comma_separated_string_of_customer_ids", False):
+            customer_ids_list = self.config.get("comma_separated_string_of_customer_ids").replace(" ", "").split(",")
+            for i in customer_ids_list:
                 yield {"customerClient": {"id": str(i)}}
         else:
             for row in self.request_records(context):

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -278,7 +278,7 @@ class ClickViewReportStream(ReportsStream):
             for record in super().get_records(context):
                 yield record
 
-    def sync(self, context: dict | None = None) -> None:
+    def sync(self, context):
         """Sync this stream.
 
         This method is internal to the SDK and should not need to be overridden.

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -154,6 +154,36 @@ class ReportsStream(GoogleAdsStream):
         path = path + f"&query={self.gaql}"
         return path
 
+class ClickViewReportStream(ReportsStream):
+
+    @property
+    def gaql(self):
+        return f"""
+        SELECT
+            click_view.gclid
+            , customer.id
+            , click_view.ad_group_ad
+            , ad_group.id
+            , ad_group.name
+            , campaign.id
+            , campaign.name
+            , segments.ad_network_type
+            , segments.device
+            , segments.date
+            , segments.slot
+            , metrics.clicks
+            , segments.click_type
+            , click_view.keyword
+            , click_view.keyword_info.match_type
+        FROM click_view
+        WHERE segments.date = {self._end_date}
+        """
+
+    records_jsonpath = "$.results[*]"
+    name = "stream_click_view_report"
+    primary_keys = ["click_view__gclid"]
+    replication_key = None
+    schema_filepath = SCHEMAS_DIR / "click_view_report.json"
 
 class CampaignsStream(ReportsStream):
     """Define custom stream."""

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -68,7 +68,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
 
     records_jsonpath = "$.results[*]"
     name = "stream_customer_hierarchy"
-    primary_keys = ["customer_client__id"]
+    primary_keys = ["customerClient__id"]
     replication_key = None
     parent_stream_type = AccessibleCustomers
     schema = th.PropertiesList(
@@ -188,14 +188,14 @@ class ClickViewReportStream(ReportsStream):
     records_jsonpath = "$.results[*]"
     name = "stream_click_view_report"
     primary_keys = [
-        "click_view__gclid",
-        "click_view__keyword",
-        "click_view__keyword_info__match_type",
+        "clickView__gclid",
+        "clickView__keyword",
+        "clickView__keywordInfo__matchType",
         "customer__id",
-        "ad_group__id",
+        "adGroup__id",
         "campaign__id",
         "segments__device",
-        "segments__ad_network_type",
+        "segments__adNetworkType",
         "segments__slot",
         "date"
     ]

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -27,7 +27,7 @@ class AccessibleCustomers(GoogleAdsStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        return {"resourceNames": ["customers/" + self.config.get('login_customer_id', self.config.get('customer_id'))]}
+        return {"resourceNames": ["customers/" + self.config.get('customer_id')]}
 
 
 class CustomerHierarchyStream(GoogleAdsStream):
@@ -45,7 +45,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
     @property
     def path(self):
         # Paramas
-        path = f"/customers/{self.config.get('login_customer_id', self.config.get('customer_id'))}"
+        path = f"/customers/{self.config.get('customer_id')}"
         path = path + "/googleAds:search"
         path = path + "?pageSize=10000"
         path = path + f"&query={self.gaql}"
@@ -126,7 +126,7 @@ class GeotargetsStream(GoogleAdsStream):
     @property
     def path(self):
         # Paramas
-        path = "/customers/{customer_id}"
+        path = f"/customers/{self.config.get('customer_id')}"
         path = path + "/googleAds:search"
         path = path + "?pageSize=10000"
         path = path + f"&query={self.gaql}"

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -26,7 +26,7 @@ class AccessibleCustomers(GoogleAdsStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        return {"resourceNames": ["customers/" + self.config.get("customer_id")]}
+        return {"resourceNames": ["customers/" + self.config.get('login_customer_id', self.config.get('customer_id'))]}
 
 
 class CustomerHierarchyStream(GoogleAdsStream):
@@ -44,7 +44,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
     @property
     def path(self):
         # Paramas
-        path = f"/customers/{self.config.get('customer_id')}"
+        path = f"/customers/{self.config.get('login_customer_id', self.config.get('customer_id'))}"
         path = path + "/googleAds:search"
         path = path + "?pageSize=10000"
         path = path + f"&query={self.gaql}"
@@ -109,7 +109,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
         """Return a context dictionary for child streams."""
-        return {"customer_id": self.config.get("customer_id")}
+        return {"customer_id": record["customerClient"]["id"]}
 
 
 class GeotargetsStream(GoogleAdsStream):
@@ -120,7 +120,7 @@ class GeotargetsStream(GoogleAdsStream):
     @property
     def path(self):
         # Paramas
-        path = f"/customers/{self.config.get('customer_id')}"
+        path = "/customers/{customer_id}"
         path = path + "/googleAds:search"
         path = path + "?pageSize=10000"
         path = path + f"&query={self.gaql}"
@@ -148,7 +148,7 @@ class ReportsStream(GoogleAdsStream):
     @property
     def path(self):
         # Paramas
-        path = f"/customers/{self.config.get('customer_id')}"
+        path = "/customers/{customer_id}"
         path = path + "/googleAds:search"
         path = path + "?pageSize=10000"
         path = path + f"&query={self.gaql}"

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -189,7 +189,6 @@ class ClickViewReportStream(ReportsStream):
     name = "stream_click_view_report"
     primary_keys = [
         "click_view__gclid",
-        "click_view__ad_group_ad",
         "click_view__keyword",
         "click_view__keyword_info__match_type",
         "customer__id",

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -68,6 +68,11 @@ class TapGoogleAds(Tap):
             th.StringType,
             description="Value to use in the login-customer-id header, if different from the customer_id to sync. Useful if you are syncing using a manager account.",
         ),
+        th.Property(
+            "array_of_customer_ids",
+            th.ArrayType(th.IntegerType),
+            description="Overrides the taps default get all data for all available customers logic, and will get you the data for only the the provided customer_ids",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -17,6 +17,7 @@ from tap_googleads.streams import (
     CustomerHierarchyStream,
     GeoPerformance,
     GeotargetsStream,
+    ClickViewReportStream,
 )
 
 STREAM_TYPES = [
@@ -31,6 +32,7 @@ STREAM_TYPES = [
     CampaignPerformanceByLocation,
     GeotargetsStream,
     GeoPerformance,
+    ClickViewReportStream,
 ]
 
 

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -32,7 +32,6 @@ STREAM_TYPES = [
     CampaignPerformanceByLocation,
     GeotargetsStream,
     GeoPerformance,
-    ClickViewReportStream,
 ]
 
 
@@ -73,8 +72,16 @@ class TapGoogleAds(Tap):
             th.ArrayType(th.IntegerType),
             description="Overrides the taps default get all data for all available customers logic, and will get you the data for only the the provided customer_ids",
         ),
+        th.Property(
+            "enable_click_view_report_stream",
+            th.BooleanType,
+            description="Enables the tap's ClickViewReportStream. This requires setting up / permission on your google ads account(s)",
+        ),
     ).to_dict()
 
     def discover_streams(self) -> List[Stream]:
         """Return a list of discovered streams."""
+        if self.config.get("enable_click_view_report_stream"):
+            if self.config.get("enable_click_view_report_stream") == True:
+                STREAM_TYPES.append(ClickViewReportStream)
         return [stream_class(tap=self) for stream_class in STREAM_TYPES]

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -68,8 +68,8 @@ class TapGoogleAds(Tap):
             description="Value to use in the login-customer-id header, if different from the customer_id to sync. Useful if you are syncing using a manager account.",
         ),
         th.Property(
-            "array_of_customer_ids",
-            th.ArrayType(th.IntegerType),
+            "comma_separated_string_of_customer_ids",
+            th.StringType,
             description="Overrides the taps default get all data for all available customers logic, and will get you the data for only the the provided customer_ids",
         ),
         th.Property(


### PR DESCRIPTION
- New `comma_separated_string_of_customer_ids` setting, allowing a user to provide a specific comma separated string of customer_ids to get data for.
- Updated new default behavior of  `CustomerHierarchyStream`. This stream now output all available `customer_id`s and will sync data for all of them. (With the new setting `array_of_customer_ids` to override the behavior if wanted).
- New `ClickViewReportStream`, with state
- Added new optional setting to enable the `ClickViewReportStream` stream, as I seems this endpoint requires either more set up or more permissions on the google ads account.
- Updated README with info about new settings
