### PR TITLE
fix: Determine customers already encountered from any previous context during runtime only

### DIFF
--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -97,6 +97,8 @@ class CustomerHierarchyStream(GoogleAdsStream):
         ),
     ).to_dict()
 
+    seen_customer_ids = set()
+
     def post_process(
         self,
         row: Record,
@@ -143,11 +145,10 @@ class CustomerHierarchyStream(GoogleAdsStream):
         customer_id = record["customerClient"]["id"]
 
         # skip if we've already seen this customer
-        if all(
-            any(ctx["customer_id"] == customer_id for ctx in cs.partitions or [])
-            for cs in self.child_streams
-        ):
+        if customer_id in self.seen_customer_ids:
             return None
+
+        self.seen_customer_ids.add(customer_id)
 
         return {"customer_id": customer_id}
 


### PR DESCRIPTION
#45 introduced some logic to attempt to remove already encountered customer IDs, in the case when `CustomerHierarchyStream` returned the same customer ID for multiple parent contexts.

https://github.com/Matatika/tap-googleads/pull/45#discussion_r1774829253 

The issue with this is that when state is provided, the child streams are always skipped because the tap thinks it has already seen those customer IDs for the current run. The correct way should be to keep track of "seen" customers at runtime only, without respect to state (via `partitions` here). 