### PR TITLE
feat: Validation format of customer IDs from config

### DIFF
--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -75,7 +75,7 @@ class GoogleAdsStream(RESTStream):
             headers["User-Agent"] = self.config.get("user_agent")
         headers["developer-token"] = self.config["developer_token"]
         headers["login-customer-id"] = (
-            self.config.get("login_customer_id")
+            self.login_customer_id
             or self.context
             and self.context.get("customer_id")
         )
@@ -120,8 +120,24 @@ class GoogleAdsStream(RESTStream):
     @cached_property
     def customer_ids(self):
         customer_ids = self.config.get("customer_ids")
-        if customer_ids is not None:
-            return customer_ids
-
         customer_id = self.config.get("customer_id")
-        return customer_id and [customer_id]
+
+        if customer_ids is None:
+            if customer_id is None:
+                return
+            customer_ids = [customer_id]
+
+        return list(map(_sanitise_customer_id, customer_ids))
+
+    @cached_property
+    def login_customer_id(self):
+        login_customer_id = self.config.get("login_customer_id")
+
+        if login_customer_id is None:
+            return
+
+        return _sanitise_customer_id(login_customer_id)
+
+
+def _sanitise_customer_id(customer_id: str):
+    return customer_id.replace("-", "")

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -35,6 +35,8 @@ STREAM_TYPES = [
     GeoPerformance,
 ]
 
+CUSTOMER_ID_TYPE = th.StringType(pattern=r"^[0-9]{3}-?[0-9]{3}-?[0-9]{4}$")
+
 
 class TapGoogleAds(Tap):
     """GoogleAds tap class."""
@@ -93,17 +95,17 @@ class TapGoogleAds(Tap):
         ),
         th.Property(
             "login_customer_id",
-            th.StringType,
+            CUSTOMER_ID_TYPE,
             description="Value to use in the login-customer-id header if using a manager customer account. See https://developers.google.com/search-ads/reporting/concepts/login-customer-id for more info.",
         ),
         th.Property(
             "customer_ids",
-            th.ArrayType(th.StringType),
+            th.ArrayType(CUSTOMER_ID_TYPE),
             description="Get data for the provided customers only, rather than all accessible customers. Takes precedence over `customer_id`.",
         ),
         th.Property(
             "customer_id",
-            th.StringType,
+            CUSTOMER_ID_TYPE,
             description="Get data for the provided customer only, rather than all accessible customers. Superseeded by `customer_ids`.",
         ),
         th.Property(


### PR DESCRIPTION
Config validation for
- `customer_ids`
- `customer_id`
- `login_customer_id`

Support hyphenated and non-hyphenated ID formats

---

Closes #67