### PR TITLE
fix: handle sub accounts properly

### DIFF
--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 from functools import cached_property
-from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import requests
@@ -57,13 +56,6 @@ class GoogleAdsStream(RESTStream):
             return base_msg + main_message
         except Exception:
             return base_msg
-
-    def validate_response(self, response):
-        if response.status_code == HTTPStatus.FORBIDDEN:
-            msg = self.response_error_message(response)
-            raise ResumableAPIError(msg, response)
-
-        super().validate_response(response)
 
     @cached_property
     def authenticator(self) -> OAuthAuthenticator:

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -98,6 +98,15 @@ class GoogleAdsStream(RESTStream):
             auth_headers=auth_headers,
         )
 
+    def _get_login_customer_id(self, context):
+        if self.login_customer_id:
+            return self.login_customer_id
+        if context:
+            if context.get("parent_customer_id"):
+                return context.get("parent_customer_id")
+            return context.get("customer_id")
+        return None
+
     @property
     def http_headers(self) -> dict:
         """Return the http headers needed."""
@@ -105,11 +114,7 @@ class GoogleAdsStream(RESTStream):
         if "user_agent" in self.config:
             headers["User-Agent"] = self.config.get("user_agent")
         headers["developer-token"] = self.config["developer_token"]
-        headers["login-customer-id"] = (
-            self.login_customer_id
-            or self.context
-            and self.context.get("customer_id")
-        )
+        headers["login-customer-id"] = self._get_login_customer_id(self.context)
         return headers
 
     def get_url_params(

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -114,7 +114,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
         if customer_ids is None:
             customer = record["customerClient"]
 
-            if customer["manager"] or customer["level"] == 0:
+            if customer["manager"]:
                 self.logger.warning(
                     "%s is a manager, skipping",
                     customer["clientCustomer"],

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -114,7 +114,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
         if customer_ids is None:
             customer = record["customerClient"]
 
-            if customer["manager"]:
+            if customer["manager"] or customer["level"] == 0:
                 self.logger.warning(
                     "%s is a manager, skipping",
                     customer["clientCustomer"],

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import datetime
+from http import HTTPStatus
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Iterable
 
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
-from tap_googleads.client import GoogleAdsStream
+from tap_googleads.client import GoogleAdsStream, ResumableAPIError
 
 if TYPE_CHECKING:
     from singer_sdk.helpers.types import Context, Record
@@ -99,6 +100,13 @@ class CustomerHierarchyStream(GoogleAdsStream):
     ).to_dict()
 
     seen_customer_ids = set()
+
+    def validate_response(self, response):
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            msg = self.response_error_message(response)
+            raise ResumableAPIError(msg, response)
+
+        super().validate_response(response)
 
     def generate_child_contexts(self, record, context):
         customer_ids = self.customer_ids
@@ -251,6 +259,17 @@ class ClickViewReportStream(ReportsStream):
                 self._increment_stream_state({"date": self.date.isoformat()}, context=self.context)
 
             yield from records
+
+    def validate_response(self, response):
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            error = response.json()["error"]["details"][0]["errors"][0]
+            msg = (
+                "Click view report not accessible to customer "
+                f"'{self.context['customer_id']}': {error['message']}"
+            )
+            raise ResumableAPIError(msg, response)
+
+        super().validate_response(response)
 
 
 class CampaignsStream(ReportsStream):

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -73,6 +73,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
           customer_client.time_zone,
           customer_client.id
         FROM customer_client
+        WHERE customer_client.level <= 1
 	"""
 
     records_jsonpath = "$.results[*]"


### PR DESCRIPTION
Related to https://github.com/Matatika/tap-googleads/issues/79 and https://github.com/Matatika/tap-googleads/pull/83

I noticed that not all customers were coming through for me and after digging deeper it looks like the cause of the `403 Client Error: Forbidden for path` I was experiencing is due to our requests not passing the proper `login-customer-id` when a customer account is a sub account. I reverted the changes in https://github.com/Matatika/tap-googleads/pull/83 as part of this and stopped seeing errors. I'm happy to not do that but I think this is the root cause so its better to throw errors again rather than silently skip.

Hierarchy:
- AccessibleCustomers -> customers
  - CustomerHierarchyStream -> customer accounts
    - AdGroupsStream -> customer account records
    - CampaignsStream
    - etc. 

This is my best attempt to describe whats happening 😅 :
- AccessibleCustomers gets accessible customers and passes their ids to the child stream CustomerHierarchyStream as context
    - CustomerHierarchyStream then makes another request for accounts within that parent's accessible customer id. These are passed down as context to all other account streams (ads, ad groups, campaigns, etc)
        - The context thats passed down to account streams includes the account customer id which is then used to make requests directly on that account for ads, etc. `/customers/{customer_id}/googleAds:search?query=`
        - We were treating every account as a top level account so in the case where we have sub accounts we get a 403 forbidden even though we already know that we have access by way of the `AccessibleCustomers` parent request.  These sub account need to be fetched slightly differently.
        - If an account is the top level then when making requests we set `login-customer-id` to the account customer ID we get from the parent record context (defined by CustomerHierarchyStream). `/customers/1234/googleAds:search?query=` and `login-customer-id=1234`
        - if an account is a sub account we need to set `login-customer-id` to the customer id passed down from AccessibleCustomers since we'll be querying through that customer to get the data. `/customers/5678/googleAds:search?query=` and `login-customer-id=1234`