### PR TITLE
Feature/hgi 7689 - Properly fail sync if bad `customer_id` provided

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,4 @@ dmypy.json
 
 # vscode settings
 .vscode
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ https://developers.google.com/google-ads/api/docs/first-call/dev-token
 
 Required settings:
 
-- `oauth_credentials.client_id`
-- `oauth_credentials.client_secret`
-- `oauth_credentials.refresh_token`
+- `client_id`
+- `client_secret`
+- `refresh_token`
 - `developer_token`
 
 Optional settings:
@@ -81,13 +81,13 @@ These are not intended for a user to set manually, as such setting them could ca
 
 Also set in by default in your [Matatika](https://www.matatika.com/) workspace environment:
 
-- `oauth_credentials.client_id`
-- `oauth_credentials_client_secret`
-- `oauth_credentials.authorization_url`
-- `oauth_credentials.scope`
-- `oauth_credentials.access_token`
-- `oauth_credentials.refresh_token`
-- `oauth_credentials.refresh_proxy_url`
+- `client_id`
+- `client_secret`
+- `authorization_url`
+- `scope`
+- `access_token`
+- `refresh_token`
+- `refresh_proxy_url`
 
 
 ### Source Authentication and Authorization

--- a/README.md
+++ b/README.md
@@ -58,7 +58,9 @@ Optional settings:
 Config for settings that refer to a customer ID should be provided as a string comprising of 10 numeric characters (e.g. `123-456-7890` or `1234567890`).
 
 #### `customer_ids`/`customer_id`
-If `customer_ids` is provided, the tap will sync get data for the corrsponding customer accounts only. The same is true for `customer_id` but for a single customer account. If both are provided, `customer_ids` takes precedence. If neither are provided, all customer accounts available to the authenticated principal are synced. 
+If `customer_ids` is provided, the tap will sync get data for the corresponding customer accounts only. The same is true for `customer_id` but for a single customer account. If both are provided, `customer_ids` takes precedence. If neither are provided, all customer accounts available to the authenticated principal are synced. 
+
+If the passed `customer-id`s are manager accounts, their children will be synced.
 
 #### `login_customer_id`
 If authenticated as a manager account, `login_customer_id` should be set to the customer ID of the manager account.

--- a/meltano.yml
+++ b/meltano.yml
@@ -14,17 +14,17 @@ plugins:
     - catalog
     - discover
     settings:
-    - name: oauth_credentials.refresh_token
+    - name: refresh_token
       kind: string
       sensitive: true
-    - name: oauth_credentials.client_id
-    - name: oauth_credentials.client_secret
+    - name: client_id
+    - name: client_secret
       kind: string
       sensitive: true
-    - name: oauth_credentials.refresh_proxy_url
+    - name: refresh_proxy_url
       kind: string
       hidden: true
-    - name: oauth_credentials.refresh_proxy_url_auth
+    - name: refresh_proxy_url_auth
       kind: string
       hidden: true
     - name: developer_token

--- a/poetry.lock
+++ b/poetry.lock
@@ -1010,13 +1010,13 @@ use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
 name = "responses"
-version = "0.25.3"
+version = "0.25.6"
 description = "A utility library for mocking out the `requests` Python library."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "responses-0.25.3-py3-none-any.whl", hash = "sha256:521efcbc82081ab8daa588e08f7e8a64ce79b91c39f6e62199b19159bea7dbcb"},
-    {file = "responses-0.25.3.tar.gz", hash = "sha256:617b9247abd9ae28313d57a75880422d55ec63c29d33d629697590a034358dba"},
+    {file = "responses-0.25.6-py3-none-any.whl", hash = "sha256:9cac8f21e1193bb150ec557875377e41ed56248aed94e4567ed644db564bacf1"},
+    {file = "responses-0.25.6.tar.gz", hash = "sha256:eae7ce61a9603004e76c05691e7c389e59652d91e94b419623c12bbfb8e331d8"},
 ]
 
 [package.dependencies]
@@ -1561,4 +1561,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "f55b8e8193adb378fa7b836024451d59d5353d9af375225ab119d72f8288e2f7"
+content-hash = "b3182e1e9e0c76309efd153142fe5b1fc98b3a830197e2c366952b381d260a9e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ black = "^24.8"
 pydocstyle = "^6.1.1"
 mypy = "^1.14"
 types-requests = "^2.32.0"
-responses = "0.25.3"
+responses = "0.25.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ keywords = [
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "^3.8"
+python = "^3.7"
 requests = "^2.25.1"
 singer-sdk = "0.42.1"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = "Apache 2.0"
 python = "^3.7"
 requests = "^2.25.1"
 singer-sdk = "0.33.1"
+"backports.cached-property" = "^1.0.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,3 +31,5 @@ build-backend = "poetry.core.masonry.api"
 [tool.poetry.scripts]
 # CLI declaration
 tap-googleads = 'tap_googleads.tap:TapGoogleAds.cli'
+tap-adwords = 'tap_googleads.tap:TapGoogleAds.cli'
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "Apache 2.0"
 [tool.poetry.dependencies]
 python = "^3.7"
 requests = "^2.25.1"
-singer-sdk = "0.42.1"
+singer-sdk = "0.33.1"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,20 +10,20 @@ keywords = [
 license = "Apache 2.0"
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.7.1, <3.11"
 requests = "^2.25.1"
 singer-sdk = "0.33.1"
 "backports.cached-property" = "^1.0.1"
 
 [tool.poetry.dev-dependencies]
-pytest = "^8.3.4"
-tox = "^4.23.2"
+pytest = "<8.3.4"
+tox = "<4.23.2"
 flake8 = "^5.0.4"
-black = "^24.8"
+black = "<24.8"
 pydocstyle = "^6.1.1"
-mypy = "^1.14"
-types-requests = "^2.32.0"
-responses = "0.25.6"
+mypy = "<1.14"
+types-requests = "<2.32.0"
+responses = "<0.25.6"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -40,7 +40,8 @@ class GoogleAdsStream(RESTStream):
         if self.config.get("customer_id"):
             self._config["customer_ids"] = [_sanitise_customer_id(self.config.get("customer_id"))]
         elif self.config.get("customer_ids"):
-            self._config["customer_ids"] = list(map(_sanitise_customer_id, self.config.get("customer_ids")))
+            raw_customer_ids = self.config.get("customer_ids").split(",")
+            self._config["customer_ids"] = list(map(_sanitise_customer_id, raw_customer_ids))
 
     def response_error_message(self, response: requests.Response) -> str:
         """Build error message for invalid http statuses.
@@ -220,4 +221,4 @@ class GoogleAdsStream(RESTStream):
                 )
 
 def _sanitise_customer_id(customer_id: str):
-    return customer_id.replace("-", "")
+    return customer_id.replace("-", "").strip()

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -63,11 +63,11 @@ class GoogleAdsStream(RESTStream):
         base_auth_url = "https://www.googleapis.com/oauth2/v4/token"
         # Silly way to do parameters but it works
 
-        client_id = self.config.get("oauth_credentials", {}).get("client_id", None)
-        client_secret = self.config.get("oauth_credentials", {}).get(
+        client_id = self.config.get("client_id", None)
+        client_secret = self.config.get(
             "client_secret", None
         )
-        refresh_token = self.config.get("oauth_credentials", {}).get(
+        refresh_token = self.config.get(
             "refresh_token", None
         )
 
@@ -79,21 +79,19 @@ class GoogleAdsStream(RESTStream):
         if client_id and client_secret and refresh_token:
             return GoogleAdsAuthenticator(stream=self, auth_endpoint=auth_url)
 
-        oauth_credentials = self.config.get("oauth_credentials", {})
-
         auth_body = {}
         auth_headers = {}
 
-        auth_body["refresh_token"] = oauth_credentials.get("refresh_token")
+        auth_body["refresh_token"] = self.config.get("refresh_token")
         auth_body["grant_type"] = "refresh_token"
 
-        auth_headers["authorization"] = oauth_credentials.get("refresh_proxy_url_auth")
+        auth_headers["authorization"] = self.config.get("refresh_proxy_url_auth")
         auth_headers["Content-Type"] = "application/json"
         auth_headers["Accept"] = "application/json"
 
         return ProxyGoogleAdsAuthenticator(
             stream=self,
-            auth_endpoint=oauth_credentials.get("refresh_proxy_url"),
+            auth_endpoint=self.config.get("refresh_proxy_url"),
             auth_body=auth_body,
             auth_headers=auth_headers,
         )
@@ -146,7 +144,7 @@ class GoogleAdsStream(RESTStream):
 
     @cached_property
     def end_date(self):
-        return datetime.fromisoformat(self.config["end_date"]).strftime(r"'%Y-%m-%d'")
+        return datetime.fromisoformat(self.config["end_date"]).strftime(r"'%Y-%m-%d'") if self.config.get("end_date") else datetime.now().strftime(r"'%Y-%m-%d'")
 
     @cached_property
     def customer_ids(self):

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -26,6 +26,10 @@ class GoogleAdsStream(RESTStream):
     next_page_token_jsonpath = "$.nextPageToken"  # Or override `get_next_page_token`.
     _LOG_REQUEST_METRIC_URLS: bool = True
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._config["customer_id"] = _sanitise_customer_id(self.config.get("customer_id"))
+
     def response_error_message(self, response: requests.Response) -> str:
         """Build error message for invalid http statuses.
 
@@ -141,7 +145,10 @@ class GoogleAdsStream(RESTStream):
 
     @cached_property
     def start_date(self):
-        return datetime.fromisoformat(self.config["start_date"]).strftime(r"'%Y-%m-%d'")
+        try:
+            return datetime.fromisoformat(self.config["start_date"]).strftime(r"'%Y-%m-%d'")
+        except Exception:
+            return datetime.strptime(self.config["start_date"], "%Y-%m-%dT%H:%M:%SZ").strftime(r"'%Y-%m-%d'")
 
     @cached_property
     def end_date(self):

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -37,7 +37,10 @@ class GoogleAdsStream(RESTStream):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._config["customer_id"] = _sanitise_customer_id(self.config.get("customer_id"))
+        if self.config.get("customer_id"):
+            self._config["customer_ids"] = [_sanitise_customer_id(self.config.get("customer_id"))]
+        elif self.config.get("customer_ids"):
+            self._config["customer_ids"] = list(map(_sanitise_customer_id, self.config.get("customer_ids")))
 
     def response_error_message(self, response: requests.Response) -> str:
         """Build error message for invalid http statuses.

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -135,9 +135,8 @@ class GoogleAdsStream(RESTStream):
         params: dict = {}
         if next_page_token:
             params["pageToken"] = next_page_token
-        if self.replication_key:
-            params["sort"] = "asc"
-            params["order_by"] = self.replication_key
+        if self.gaql:
+            params["query"] = self.gaql(context)
         return params
 
     def get_records(self, context):
@@ -152,16 +151,13 @@ class GoogleAdsStream(RESTStream):
 
     @property
     def path(self) -> str:
-        # Paramas
-        path = "/customers/{customer_id}/googleAds:search?query="
-        return path + self.gaql
+        path = "/customers/{customer_id}/googleAds:search"
+        return path
 
-    @cached_property
-    def start_date(self):
-        try:
-            return datetime.fromisoformat(self.config["start_date"]).strftime(r"'%Y-%m-%d'")
-        except Exception:
-            return datetime.strptime(self.config["start_date"], "%Y-%m-%dT%H:%M:%SZ").strftime(r"'%Y-%m-%d'")
+    def start_date(self, context=None):
+        start_value = self.get_starting_replication_key_value(context)
+        start_date =  f"'{parse(start_value).date()}'"
+        return start_date
 
     @cached_property
     def end_date(self):

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -103,11 +103,12 @@ class GoogleAdsStream(RESTStream):
         if "user_agent" in self.config:
             headers["User-Agent"] = self.config.get("user_agent")
         headers["developer-token"] = self.config["developer_token"]
-        headers["login-customer-id"] = (
-            self.login_customer_id
-            or self.context
-            and self.context.get("customer_id")
-        )
+        if self.login_customer_id:
+            headers["login-customer-id"] = (
+                self.login_customer_id
+                # or self.context
+                # and self.context.get("customer_id")
+            )
         return headers
 
     def get_url_params(

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -1,7 +1,7 @@
 """REST client handling, including GoogleAdsStream base class."""
 
 from datetime import datetime
-from functools import cached_property
+from backports.cached_property import cached_property
 from typing import Any, Dict, Optional
 
 import requests

--- a/tap_googleads/schemas/ad_group.json
+++ b/tap_googleads/schemas/ad_group.json
@@ -1,71 +1,50 @@
 {
     "type": "object",
     "properties": {
-        "adGroup": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "type": {
-                    "type": "string"
-                },
-                "targetingSetting": {
-                    "type": "object",
-                    "properties": {
-                        "targetRestrictions": {
-                            "type": "array",
-                            "items": {
-                                "type": "object",
-                                "properties": {
-                                    "targetingDimension": {
-                                        "type": "string"
-                                    },
-                                    "bidOnly": {
-                                        "type": "boolean"
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                "id": {
-                    "type": "string"
-                },
-                "customer_id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "baseAdGroup": {
-                    "type": "string"
-                },
-                "campaign": {
-                    "type": "string"
-                },
-                "cpcBidMicros": {
-                    "type": "string"
-                },
-                "cpmBidMicros": {
-                    "type": "string"
-                },
-                "targetCpaMicros": {
-                    "type": "string"
-                },
-                "cpvBidMicros": {
-                    "type": "string"
-                },
-                "targetCpmMicros": {
-                    "type": "string"
-                },
-                "effectiveTargetCpaMicros": {
-                    "type": "string"
-                }
-            }
+        "adGroup__resourceName": {
+            "type": ["string", "null"]
+        },
+        "adGroup__status": {
+            "type": ["string", "null"]
+        },
+        "adGroup__type": {
+            "type": ["string", "null"]
+        },
+        "adGroup__targetingSetting__targetRestrictions": {
+            "type": ["string", "null"]
+        },
+        "adGroup__id": {
+            "type": ["string", "null"]
+        },
+        "adGroup__customer_id": {
+            "type": ["string", "null"]
+        },
+        "adGroup__name": {
+            "type": ["string", "null"]
+        },
+        "adGroup__baseAdGroup": {
+            "type": ["string", "null"]
+        },
+        "adGroup__campaign": {
+            "type": ["string", "null"]
+        },
+        "adGroup__cpcBidMicros": {
+            "type": ["string", "null"]
+        },
+        "adGroup__cpmBidMicros": {
+            "type": ["string", "null"]
+        },
+        "adGroup__targetCpaMicros": {
+            "type": ["string", "null"]
+        },
+        "adGroup__cpvBidMicros": {
+            "type": ["string", "null"]
+        },
+        "adGroup__targetCpmMicros": {
+            "type": ["string", "null"]
+        },
+        "adGroup__effectiveTargetCpaMicros": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/adgroups_performance.json
+++ b/tap_googleads/schemas/adgroups_performance.json
@@ -2,43 +2,28 @@
     "type": "object",
     "properties": {
         "customer_id": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "campaign": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            }
+        "campaign__resourceName": {
+            "type": ["string", "null"]
         },
-        "adGroup": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            }
+        "campaign__id": {
+            "type": ["string", "null"]
         },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "clicks": {
-                    "type": "string"
-                },
-                "costMicros": {
-                    "type": "string"
-                },
-                "impressions": {
-                    "type": "string"
-                }
-            }
+        "adGroup__resourceName": {
+            "type": ["string", "null"]
+        },
+        "adGroup__id": {
+            "type": ["string", "null"]
+        },
+        "metrics__clicks": {
+            "type": ["string", "null"]
+        },
+        "metrics__costMicros": {
+            "type": ["string", "null"]
+        },
+        "metrics__impressions": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/adgroups_performance.json
+++ b/tap_googleads/schemas/adgroups_performance.json
@@ -24,6 +24,10 @@
         },
         "metrics__impressions": {
             "type": ["string", "null"]
+        },
+        "segments__date": {
+            "type": ["string", "null"],
+            "format": "date"
         }
     }
 }

--- a/tap_googleads/schemas/campaign.json
+++ b/tap_googleads/schemas/campaign.json
@@ -2,21 +2,16 @@
     "type": "object",
     "properties": {
         "customer_id": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "campaign": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                }
-            }
+        "campaign__resourceName": {
+            "type": ["string", "null"]
+        },
+        "campaign__name": {
+            "type": ["string", "null"]
+        },
+        "campaign__id": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/campaign_performance.json
+++ b/tap_googleads/schemas/campaign_performance.json
@@ -2,52 +2,37 @@
     "type": "object",
     "properties": {
         "customer_id": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "campaign": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "campaign__resourceName": {
+            "type": ["string", "null"]
         },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "clicks": {
-                    "type": "string"
-                },
-                "costMicros": {
-                    "type": "string"
-                },
-                "ctr": {
-                    "type": "number"
-                },
-                "averageCpc": {
-                    "type": "number"
-                },
-                "impressions": {
-                    "type": "string"
-                }
-            }
+        "campaign__status": {
+            "type": ["string", "null"]
         },
-        "segments": {
-            "type": "object",
-            "properties": {
-                "device": {
-                    "type": "string"
-                },
-                "date": {
-                    "type": "string"
-                }
-            }
+        "campaign__name": {
+            "type": ["string", "null"]
+        },
+        "metrics__clicks": {
+            "type": ["string", "null"]
+        },
+        "metrics__costMicros": {
+            "type": ["string", "null"]
+        },
+        "metrics__ctr": {
+            "type": ["number", "null"]
+        },
+        "metrics__averageCpc": {
+            "type": ["number", "null"]
+        },
+        "metrics__impressions": {
+            "type": ["string", "null"]
+        },
+        "segments__device": {
+            "type": ["string", "null"]
+        },
+        "segments__date": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/campaign_performance_by_age_range_and_device.json
+++ b/tap_googleads/schemas/campaign_performance_by_age_range_and_device.json
@@ -2,90 +2,55 @@
     "type": "object",
     "properties": {
         "customer_id": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "campaign": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "advertisingChannelType": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "campaign__resourceName": {
+            "type": ["string", "null"]
         },
-        "adGroup": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "campaign__status": {
+            "type": ["string", "null"]
         },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "clicks": {
-                    "type": "string"
-                },
-                "costMicros": {
-                    "type": "string"
-                },
-                "ctr": {
-                    "type": "number"
-                },
-                "averageCpc": {
-                    "type": "number"
-                },
-                "impressions": {
-                    "type": "string"
-                }
-            }
+        "campaign__advertisingChannelType": {
+            "type": ["string", "null"]
         },
-        "adGroupCriterion": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "ageRange": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+        "campaign__name": {
+            "type": ["string", "null"]
         },
-        "ageRangeView": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                }
-            }
+        "adGroup__resourceName": {
+            "type": ["string", "null"]
         },
-        "segments": {
-            "type": "object",
-            "properties": {
-                "device": {
-                    "type": "string"
-                },
-                "date": {
-                    "type": "string"
-                }
-            }
+        "adGroup__name": {
+            "type": ["string", "null"]
+        },
+        "metrics__clicks": {
+            "type": ["string", "null"]
+        },
+        "metrics__costMicros": {
+            "type": ["string", "null"]
+        },
+        "metrics__ctr": {
+            "type": ["number", "null"]
+        },
+        "metrics__averageCpc": {
+            "type": ["number", "null"]
+        },
+        "metrics__impressions": {
+            "type": ["string", "null"]
+        },
+        "adGroupCriterion__resourceName": {
+            "type": ["string", "null"]
+        },
+        "adGroupCriterion__ageRange__type": {
+            "type": ["string", "null"]
+        },
+        "ageRangeView__resourceName": {
+            "type": ["string", "null"]
+        },
+        "segments__device": {
+            "type": ["string", "null"]
+        },
+        "segments__date": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/campaign_performance_by_gender_and_device.json
+++ b/tap_googleads/schemas/campaign_performance_by_gender_and_device.json
@@ -65,6 +65,15 @@
                             "type": "string"
                         }
                     }
+                },
+                "systemServingStatus": {
+                    "type": "string",
+                    "enum": [
+                        "ELIGIBLE",
+                        "RARELY_SERVED",
+                        "UNKNOWN",
+                        "UNSPECIFIED"
+                    ]
                 }
             }
         },

--- a/tap_googleads/schemas/campaign_performance_by_gender_and_device.json
+++ b/tap_googleads/schemas/campaign_performance_by_gender_and_device.json
@@ -2,99 +2,64 @@
     "type": "object",
     "properties": {
         "customer_id": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "campaign": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "advertisingChannelType": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "campaign__resourceName": {
+            "type": ["string", "null"]
         },
-        "adGroup": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "campaign__status": {
+            "type": ["string", "null"]
         },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "clicks": {
-                    "type": "string"
-                },
-                "costMicros": {
-                    "type": "string"
-                },
-                "ctr": {
-                    "type": "number"
-                },
-                "averageCpc": {
-                    "type": "number"
-                },
-                "impressions": {
-                    "type": "string"
-                }
-            }
+        "campaign__advertisingChannelType": {
+            "type": ["string", "null"]
         },
-        "adGroupCriterion": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "gender": {
-                    "type": "object",
-                    "properties": {
-                        "type": {
-                            "type": "string"
-                        }
-                    }
-                },
-                "systemServingStatus": {
-                    "type": "string",
-                    "enum": [
-                        "ELIGIBLE",
-                        "RARELY_SERVED",
-                        "UNKNOWN",
-                        "UNSPECIFIED"
-                    ]
-                }
-            }
+        "campaign__name": {
+            "type": ["string", "null"]
         },
-        "genderView": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                }
-            }
+        "adGroup__resourceName": {
+            "type": ["string", "null"]
         },
-        "segments": {
-            "type": "object",
-            "properties": {
-                "device": {
-                    "type": "string"
-                },
-                "date": {
-                    "type": "string"
-                }
-            }
+        "adGroup__name": {
+            "type": ["string", "null"]
+        },
+        "metrics__clicks": {
+            "type": ["string", "null"]
+        },
+        "metrics__costMicros": {
+            "type": ["string", "null"]
+        },
+        "metrics__ctr": {
+            "type": ["number", "null"]
+        },
+        "metrics__averageCpc": {
+            "type": ["number", "null"]
+        },
+        "metrics__impressions": {
+            "type": ["string", "null"]
+        },
+        "adGroupCriterion__resourceName": {
+            "type": ["string", "null"]
+        },
+        "adGroupCriterion__gender__type": {
+            "type": ["string", "null"]
+        },
+        "adGroupCriterion__systemServingStatus": {
+            "type": ["string", "null"],
+            "enum": [
+                "ELIGIBLE",
+                "RARELY_SERVED",
+                "UNKNOWN",
+                "UNSPECIFIED"
+            ]
+        },
+        "genderView__resourceName": {
+            "type": ["string", "null"]
+        },
+        "segments__device": {
+            "type": ["string", "null"]
+        },
+        "segments__date": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/campaign_performance_by_location.json
+++ b/tap_googleads/schemas/campaign_performance_by_location.json
@@ -46,6 +46,9 @@
                     "properties": {
                         "geoTargetConstant": {
                             "type": "string"
+                        },
+                        "bidModifier": {
+                            "type": "number"
                         }
                     }
                 }

--- a/tap_googleads/schemas/campaign_performance_by_location.json
+++ b/tap_googleads/schemas/campaign_performance_by_location.json
@@ -2,73 +2,43 @@
     "type": "object",
     "properties": {
         "customer_id": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "campaign": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "campaign__resourceName": {
+            "type": ["string", "null"]
         },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "clicks": {
-                    "type": "string"
-                },
-                "costMicros": {
-                    "type": "string"
-                },
-                "ctr": {
-                    "type": "number"
-                },
-                "averageCpc": {
-                    "type": "number"
-                },
-                "impressions": {
-                    "type": "string"
-                }
-            }
+        "campaign__name": {
+            "type": ["string", "null"]
         },
-        "campaignCriterion": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "location": {
-                    "type": "object",
-                    "properties": {
-                        "geoTargetConstant": {
-                            "type": "string"
-                        },
-                        "bidModifier": {
-                            "type": "number"
-                        }
-                    }
-                }
-            }
+        "metrics__clicks": {
+            "type": ["string", "null"]
         },
-        "segments": {
-            "type": "object",
-            "properties": {
-                "date": {
-                    "type": "string"
-                }
-            }
+        "metrics__costMicros": {
+            "type": ["string", "null"]
         },
-        "locationView": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                }
-            }
+        "metrics__ctr": {
+            "type": ["number", "null"]
+        },
+        "metrics__averageCpc": {
+            "type": ["number", "null"]
+        },
+        "metrics__impressions": {
+            "type": ["string", "null"]
+        },
+        "campaignCriterion__resourceName": {
+            "type": ["string", "null"]
+        },
+        "campaignCriterion__location__geoTargetConstant": {
+            "type": ["string", "null"]
+        },
+        "campaignCriterion__location__bidModifier": {
+            "type": ["number", "null"]
+        },
+        "segments__date": {
+            "type": ["string", "null"]
+        },
+        "locationView__resourceName": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/click_view_report.json
+++ b/tap_googleads/schemas/click_view_report.json
@@ -2,86 +2,51 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
     "properties": {
-        "clickView": {
-            "type": "object",
-            "properties": {
-                "gclid": {
-                    "type": "string"
-                },
-                "adGroupAd": {
-                    "type": "string"
-                },
-                "keyword": {
-                    "type": "string"
-                },
-                "keywordInfo": {
-                    "type": "object",
-                    "properties": {
-                        "matchType": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+        "clickView__gclid": {
+            "type": ["string", "null"]
         },
-        "customer": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                }
-            }
+        "clickView__adGroupAd": {
+            "type": ["string", "null"]
         },
-        "adGroup": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "clickView__keyword": {
+            "type": ["string", "null"]
         },
-        "campaign": {
-            "type": "object",
-            "properties": {
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "clickView__keywordInfo__matchType": {
+            "type": ["string", "null"]
+        },
+        "customer__id": {
+            "type": ["string", "null"]
+        },
+        "adGroup__id": {
+            "type": ["string", "null"]
+        },
+        "adGroup__name": {
+            "type": ["string", "null"]
+        },
+        "campaign__id": {
+            "type": ["string", "null"]
+        },
+        "campaign__name": {
+            "type": ["string", "null"]
         },
         "date": {
-            "type": "string",
-            "format": "date"
+            "format": "date",
+            "type": ["string", "null"]
         },
-        "segments": {
-            "type": "object",
-            "properties": {
-                "adNetworkType": {
-                    "type": "string"
-                },
-                "device": {
-                    "type": "string"
-                },
-                "slot": {
-                    "type": "string"
-                },
-                "clickType": {
-                    "type": "string"
-                }
-            }
+        "segments__adNetworkType": {
+            "type": ["string", "null"]
         },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "clicks": {
-                    "type": "string"
-                }
-            }
+        "segments__device": {
+            "type": ["string", "null"]
+        },
+        "segments__slot": {
+            "type": ["string", "null"]
+        },
+        "segments__clickType": {
+            "type": ["string", "null"]
+        },
+        "metrics__clicks": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/geo_performance.json
+++ b/tap_googleads/schemas/geo_performance.json
@@ -46,6 +46,9 @@
         "geographicView": {
             "type": "object",
             "properties": {
+                "resourceName": {
+                    "type": "string"
+                },
                 "locationType": {
                     "type": "string"
                 },

--- a/tap_googleads/schemas/geo_performance.json
+++ b/tap_googleads/schemas/geo_performance.json
@@ -2,60 +2,40 @@
     "type": "object",
     "properties": {
         "customer_id": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "campaign": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                }
-            }
+        "campaign__resourceName": {
+            "type": ["string", "null"]
         },
-        "metrics": {
-            "type": "object",
-            "properties": {
-                "clicks": {
-                    "type": "string"
-                },
-                "costMicros": {
-                    "type": "string"
-                },
-                "impressions": {
-                    "type": "string"
-                },
-                "conversions": {
-                    "type": "number"
-                }
-            }
+        "campaign__status": {
+            "type": ["string", "null"]
         },
-        "segments": {
-            "type": "object",
-            "properties": {
-                "date": {
-                    "type": "string"
-                }
-            }
+        "campaign__name": {
+            "type": ["string", "null"]
         },
-        "geographicView": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "locationType": {
-                    "type": "string"
-                },
-                "countryCriterionId": {
-                    "type": "string"
-                }
-            }
+        "metrics__clicks": {
+            "type": ["string", "null"]
+        },
+        "metrics__costMicros": {
+            "type": ["string", "null"]
+        },
+        "metrics__impressions": {
+            "type": ["string", "null"]
+        },
+        "metrics__conversions": {
+            "type": ["number", "null"]
+        },
+        "segments__date": {
+            "type": ["string", "null"]
+        },
+        "geographicView__resourceName": {
+            "type": ["string", "null"]
+        },
+        "geographicView__locationType": {
+            "type": ["string", "null"]
+        },
+        "geographicView__countryCriterionId": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/schemas/geo_target_constant.json
+++ b/tap_googleads/schemas/geo_target_constant.json
@@ -1,6 +1,9 @@
 {
     "type": "object",
     "properties": {
+        "customer_id": {
+            "type": "string"
+        },
         "geoTargetConstant": {
             "type": "object",
             "properties": {

--- a/tap_googleads/schemas/geo_target_constant.json
+++ b/tap_googleads/schemas/geo_target_constant.json
@@ -2,33 +2,28 @@
     "type": "object",
     "properties": {
         "customer_id": {
-            "type": "string"
+            "type": ["string", "null"]
         },
-        "geoTargetConstant": {
-            "type": "object",
-            "properties": {
-                "resourceName": {
-                    "type": "string"
-                },
-                "status": {
-                    "type": "string"
-                },
-                "id": {
-                    "type": "string"
-                },
-                "name": {
-                    "type": "string"
-                },
-                "countryCode": {
-                    "type": "string"
-                },
-                "targetType": {
-                    "type": "string"
-                },
-                "canonicalName": {
-                    "type": "string"
-                }
-            }
+        "geoTargetConstant__resourceName": {
+            "type": ["string", "null"]
+        },
+        "geoTargetConstant__status": {
+            "type": ["string", "null"]
+        },
+        "geoTargetConstant__id": {
+            "type": ["string", "null"]
+        },
+        "geoTargetConstant__name": {
+            "type": ["string", "null"]
+        },
+        "geoTargetConstant__countryCode": {
+            "type": ["string", "null"]
+        },
+        "geoTargetConstant__targetType": {
+            "type": ["string", "null"]
+        },
+        "geoTargetConstant__canonicalName": {
+            "type": ["string", "null"]
         }
     }
 }

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -82,6 +82,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
     replication_key = None
     parent_stream_type = AccessibleCustomers
     schema = th.PropertiesList(
+        th.Property("customer_id", th.StringType),
         th.Property(
             "customerClient",
             th.ObjectType(

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterable
 from singer_sdk import typing as th  # JSON Schema typing helpers
 
 from tap_googleads.client import GoogleAdsStream, ResumableAPIError, _sanitise_customer_id
+from pendulum import parse
 
 if TYPE_CHECKING:
     from singer_sdk.helpers.types import Context, Record
@@ -267,8 +268,8 @@ class ClickViewReportStream(ReportsStream):
     def request_records(self, context):
         start_value = self.get_starting_replication_key_value(context)
 
-        start_date =  datetime.date.fromisoformat(start_value)
-        end_date = datetime.date.fromisoformat(self.config["end_date"])
+        start_date =  parse(start_value).date()
+        end_date = parse(self.config["end_date"]).date()
 
         delta = end_date - start_date
         dates = (start_date + datetime.timedelta(days=i) for i in range(delta.days))

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -45,10 +45,15 @@ class AccessibleCustomers(GoogleAdsStream):
             A child context for each child stream.
 
         """
+        # NOTE: the line below ensures we only get data for selected customers
+        if self.customer_ids:
+            return {"customer_ids": self.customer_ids}
+
         customer_ids = []
         for customer in record.get("resourceNames", []):
             customer_id = customer.split("/")[1]
             customer_ids.append(customer_id.replace("-", ""))
+
         return {"customer_ids": customer_ids}
 
 

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -486,9 +486,11 @@ class GeoPerformance(ReportsStream):
     name = "stream_geo_performance"
     primary_keys = [
         "geographicView__countryCriterionId",
+        "geographicView__locationType",
         "customer_id",
         "campaign__name",
-        "segments__date",
+        "campaign__status",
+        "segments__date"
     ]
     replication_key = None
     schema_filepath = SCHEMAS_DIR / "geo_performance.json"

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -408,6 +408,7 @@ class CampaignPerformanceByAgeRangeAndDevice(ReportsStream):
     records_jsonpath = "$.results[*]"
     name = "stream_campaign_performance_by_age_range_and_device"
     primary_keys = [
+        "adGroup__name",
         "adGroupCriterion__ageRange__type",
         "campaign__name",
         "segments__date",
@@ -430,6 +431,7 @@ class CampaignPerformanceByGenderAndDevice(ReportsStream):
     records_jsonpath = "$.results[*]"
     name = "stream_campaign_performance_by_gender_and_device"
     primary_keys = [
+        "adGroup__name",
         "adGroupCriterion__gender__type",
         "campaign__name",
         "segments__date",

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -87,15 +87,12 @@ class CustomerHierarchyStream(GoogleAdsStream):
 
     records_jsonpath = "$.results[*]"
     name = "stream_customer_hierarchy"
-    primary_keys = ["customerClient__id"]
+    primary_keys = ["id"]
     replication_key = None
     parent_stream_type = AccessibleCustomers
     state_partitioning_keys = ["customer_id"]
     schema = th.PropertiesList(
-        th.Property("customer_id", th.StringType),
-        th.Property(
-            "customerClient",
-            th.ObjectType(
+                th.Property("customer_id", th.StringType),
                 th.Property("resourceName", th.StringType),
                 th.Property("clientCustomer", th.StringType),
                 th.Property("level", th.StringType),
@@ -105,8 +102,6 @@ class CustomerHierarchyStream(GoogleAdsStream):
                 th.Property("descriptiveName", th.StringType),
                 th.Property("currencyCode", th.StringType),
                 th.Property("id", th.StringType),
-            ),
-        ),
     ).to_dict()
 
     seen_customer_ids = set()
@@ -156,7 +151,8 @@ class CustomerHierarchyStream(GoogleAdsStream):
                 continue
 
     def post_process(self, row, context):
-        row["customer_id"] = _sanitise_customer_id(row["customerClient"]["id"])
+        row = row["customerClient"]
+        row["customer_id"] = _sanitise_customer_id(row["id"])
         return row
 
 class ReportsStream(GoogleAdsStream):

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import copy
 import datetime
 from http import HTTPStatus
 from pathlib import Path
@@ -145,7 +146,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
                 context["customer_id"] = customer_id
                 yield from super().get_records(context)
             except Exception as e:
-                self.logger.error(f"Error processing resource name {name}: {str(e)}")
+                self.logger.error(f"Error processing resource name {customer_id}: {str(e)}")
                 continue
 
     def post_process(self, row, context):

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -86,8 +86,8 @@ class TapGoogleAds(Tap):
         ),
         th.Property(
             "customer_ids",
-            th.ArrayType(CUSTOMER_ID_TYPE),
-            description="Get data for the provided customers only, rather than all accessible customers. Takes precedence over `customer_id`.",
+            CUSTOMER_ID_TYPE,
+            description="Comma seperated string. Get data for the provided customers only, rather than all accessible customers. Takes precedence over `customer_id`.",
         ),
         th.Property(
             "customer_id",

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -36,7 +36,7 @@ STREAM_TYPES = [
     GeoPerformance,
 ]
 
-CUSTOMER_ID_TYPE = th.StringType(pattern=r"^[0-9]{3}-?[0-9]{3}-?[0-9]{4}$")
+CUSTOMER_ID_TYPE = th.StringType()
 
 
 class TapGoogleAds(Tap):

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -156,3 +156,6 @@ class TapGoogleAds(Tap):
                 "Both standard OAuth and proxy OAuth credentials provided. "
                 "Standard OAuth credentials will take precedence."
             )
+
+if __name__ == "__main__":
+    TapGoogleAds.cli()

--- a/tap_googleads/tap.py
+++ b/tap_googleads/tap.py
@@ -5,6 +5,7 @@ from typing import List
 
 from singer_sdk import Stream, Tap
 from singer_sdk import typing as th  # JSON schema typing helpers
+from singer_sdk.exceptions import ConfigValidationError
 
 from tap_googleads.streams import (
     AccessibleCustomers,
@@ -52,41 +53,26 @@ class TapGoogleAds(Tap):
     _end_date = datetime.now(timezone.utc).date()
     _start_date = _end_date - timedelta(days=90)
 
-    # TODO: Add Descriptions
     config_jsonschema = th.PropertiesList(
         th.Property(
-            "oauth_credentials",
-            th.OneOf(
-                th.ObjectType(
-                    th.Property(
-                        "client_id",
-                        th.StringType,
-                        required=True,
-                    ),
-                    th.Property(
-                        "client_secret",
-                        th.StringType,
-                        required=True,
-                        secret=True,
-                    ),
-                    _refresh_token,
-                ),
-                th.ObjectType(
-                    th.Property(
-                        "refresh_proxy_url",
-                        th.StringType,
-                        required=True,
-                    ),
-                    th.Property(
-                        "refresh_proxy_url_auth",
-                        th.StringType,
-                        secret=True,
-                    ),
-                    _refresh_token,
-                ),
-            ),
-            required=True,
+            "client_id",
+            th.StringType,
         ),
+        th.Property(
+            "client_secret",
+            th.StringType,
+            secret=True,
+        ),
+        th.Property(
+            "refresh_proxy_url",
+            th.StringType,
+        ),
+        th.Property(
+            "refresh_proxy_url_auth",
+            th.StringType,
+            secret=True,
+        ),
+        _refresh_token,
         th.Property(
             "developer_token",
             th.StringType,
@@ -140,3 +126,33 @@ class TapGoogleAds(Tap):
         if self.config["enable_click_view_report_stream"]:
             STREAM_TYPES.append(ClickViewReportStream)
         return [stream_class(tap=self) for stream_class in STREAM_TYPES]
+
+    def _validate_config(self, *, raise_errors: bool = True) -> None:
+        """Validate configuration.
+        
+        Raises:
+            ConfigValidationError: If the configuration is invalid.
+        """
+        super()._validate_config(raise_errors=raise_errors)
+
+        client_id = self.config.get("client_id")
+        client_secret = self.config.get("client_secret")
+        refresh_proxy_url = self.config.get("refresh_proxy_url")
+        refresh_proxy_url_auth = self.config.get("refresh_proxy_url_auth")
+
+        # Validate that either standard OAuth or proxy OAuth credentials are provided
+        has_standard_oauth = bool(client_id) and bool(client_secret)
+        has_proxy_oauth = bool(refresh_proxy_url) and bool(refresh_proxy_url_auth)
+
+        if not (has_standard_oauth or has_proxy_oauth):
+            raise ConfigValidationError(
+                "Authentication configuration is invalid. Must provide either:\n"
+                "1. Both 'client_id' and 'client_secret' for standard OAuth, or\n" 
+                "2. Both 'refresh_proxy_url' and 'refresh_proxy_url_auth' for proxy OAuth"
+            )
+
+        if has_standard_oauth and has_proxy_oauth:
+            self.logger.warning(
+                "Both standard OAuth and proxy OAuth credentials provided. "
+                "Standard OAuth credentials will take precedence."
+            )

--- a/tap_googleads/tests/test_base_credentials.py
+++ b/tap_googleads/tests/test_base_credentials.py
@@ -15,11 +15,9 @@ class TestTapGoogleadsWithBaseCredentials(unittest.TestCase):
 
     def setUp(self):
         self.mock_config = {
-            "oauth_credentials": {
-                "client_id": "1234",
-                "client_secret": "1234",
-                "refresh_token": "1234",
-            },
+            "client_id": "1234",
+            "client_secret": "1234",
+            "refresh_token": "1234",
             "customer_id": "1234567890",
             "developer_token": "1234",
         }

--- a/tap_googleads/tests/test_proxy_oauth.py
+++ b/tap_googleads/tests/test_proxy_oauth.py
@@ -14,11 +14,9 @@ class TestTapGoogleadsWithProxyOAuthCredentials(unittest.TestCase):
 
     def setUp(self):
         self.mock_config = {
-            "oauth_credentials": {
-                "refresh_proxy_url": "http://localhost:8080/api/tokens/oauth2-google/token",
-                "refresh_proxy_url_auth": "Bearer proxy_url_token",
-                "refresh_token": "1234",
-            },
+            "refresh_proxy_url": "http://localhost:8080/api/tokens/oauth2-google/token",
+            "refresh_proxy_url_auth": "Bearer proxy_url_token",
+            "refresh_token": "1234",
             "customer_id": "1234567890",
             "developer_token": "1234",
         }


### PR DESCRIPTION
Previously, if a invalid `customer_id` was provided, it would not appear as a result in the parent `AccessibleCustomers` stream.

This means a child stream would never be spawned for that invalid id, and consequently an error would never be thrown to catch the bad customer id