### PR TITLE
fix: Query in logs

### DIFF
--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -142,12 +142,13 @@ class GoogleAdsStream(RESTStream):
             self.logger.warning(e)
 
     @property
-    def gaql(self):
+    def gaql(self) -> str:
         raise NotImplementedError
 
     def prepare_request_payload(self, context, next_page_token):
         if self.rest_method == "POST":
-            return {"query": self.gaql}
+            santised_query = " ".join(self.gaql.split())
+            return {"query": santised_query}
 
         return None
 

--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -23,6 +23,7 @@ class GoogleAdsStream(RESTStream):
     """GoogleAds stream class."""
 
     url_base = "https://googleads.googleapis.com/v20"
+    path = "/customers/{customer_id}/googleAds:search"
     rest_method = "POST"
     records_jsonpath = "$[*]"  # Or override `parse_response`.
     next_page_token_jsonpath = "$.nextPageToken"  # Or override `get_next_page_token`.
@@ -144,11 +145,11 @@ class GoogleAdsStream(RESTStream):
     def gaql(self):
         raise NotImplementedError
 
-    @property
-    def path(self) -> str:
-        # Paramas
-        path = "/customers/{customer_id}/googleAds:search?query="
-        return path + self.gaql
+    def prepare_request_payload(self, context, next_page_token):
+        if self.rest_method == "POST":
+            return {"query": self.gaql}
+
+        return None
 
     @cached_property
     def start_date(self):


### PR DESCRIPTION
Stream queries are currently visible in logs as they are present in the URL `query` parameter. For larger queries, this causes quite a lot of log pollution. To reduce this, we can instead provide the query in the request body.