### PR TITLE
fix: Unnecessary additional access token updates during dynamic discovery

### DIFF
--- a/tap_googleads/dynamic_query_stream.py
+++ b/tap_googleads/dynamic_query_stream.py
@@ -102,7 +102,6 @@ class DynamicQueryStream(ReportsStream):
 
         payload = {"query": query, "pageSize": len(fields)}
         headers = {
-            "Authorization": f"Bearer {self.authenticator.access_token}",
             "Content-Type": "application/json",
             "developer-token": self.config["developer_token"],
         }


### PR DESCRIPTION
Small bug introduced by #103, where the access token would be updated for every stream due to unconditional `self.authenticator.update_access_token` call.