### PR TITLE
Revert "perf: Use `searchStream` endpoint"

### DIFF
--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -23,7 +23,7 @@ class GoogleAdsStream(RESTStream):
     """GoogleAds stream class."""
 
     url_base = "https://googleads.googleapis.com/v20"
-    path = "/customers/{customer_id}/googleAds:searchStream"
+    path = "/customers/{customer_id}/googleAds:search"
     rest_method = "POST"
     records_jsonpath = "$[*]"  # Or override `parse_response`.
     next_page_token_jsonpath = "$.nextPageToken"  # Or override `get_next_page_token`.

--- a/tap_googleads/custom_query_stream.py
+++ b/tap_googleads/custom_query_stream.py
@@ -6,6 +6,7 @@ from tap_googleads.dynamic_query_stream import DynamicQueryStream
 class CustomQueryStream(DynamicQueryStream):
     """Define custom stream."""
 
+    records_jsonpath = "$.results[*]"
     add_date_filter_to_query = True
 
     def __init__(self, *args, **kwargs) -> None:

--- a/tap_googleads/dynamic_query_stream.py
+++ b/tap_googleads/dynamic_query_stream.py
@@ -18,7 +18,7 @@ DATE_TYPES = ("segments.date", "segments.month", "segments.quarter", "segments.w
 class DynamicQueryStream(ReportsStream):
     """Define dynamic query stream class."""
 
-    records_jsonpath = "$[*].results[*]"
+    records_jsonpath = "$.results[*]"
     add_date_filter_to_query = False
 
     @staticmethod

--- a/tap_googleads/dynamic_streams/click_view_report.py
+++ b/tap_googleads/dynamic_streams/click_view_report.py
@@ -205,3 +205,14 @@ class ClickViewReportStream(DynamicQueryStream):
                     {"date": self.date.isoformat()}, context=self.context
                 )
             yield from records
+            
+    def validate_response(self, response):
+        if response.status_code == HTTPStatus.FORBIDDEN:
+            error = response.json()["error"]["details"][0]["errors"][0]
+            msg = (
+                "Click view report not accessible to customer "
+                f"'{self.context['customer_id']}': {error['message']}"
+            )
+            raise ResumableAPIError(msg, response)
+
+        super().validate_response(response)

--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -64,7 +64,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
     know when to query the down stream apps
     """
 
-    records_jsonpath = "$[*].results[*]"
+    records_jsonpath = "$.results[*]"
     name = "customer_hierarchy"
     primary_keys = ["customerClient__id"]
     parent_stream_type = AccessibleCustomers


### PR DESCRIPTION
Reverts Matatika/tap-googleads#107

> Memory usage may be something to keep an eye on...

We did in-fact run into memory issues. 