### PR TITLE
fix customer manager and disabled filter

### DIFF
--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -121,7 +121,7 @@ class CustomerHierarchyStream(GoogleAdsStream):
 
             if customer['manager']:
                 self.logger.warning(f"{customer['clientCustomer']} is a manager, skipping")
-                return None
+                return
 
             if customer['status'] != 'ENABLED':
                 self.logger.warning(f"{customer['clientCustomer']} is not enabled, skipping")


### PR DESCRIPTION
at the moment this would yield None but then still yield the customer afterwards if its a manager or disabled customer. These if statements should return instead of yield to stop creating a child context for manager or disabled customers_ids.