### PR TITLE
fix: Missing data for customers with `customer_id(s)` config

### DIFF
--- a/tap_googleads/streams.py
+++ b/tap_googleads/streams.py
@@ -135,6 +135,13 @@ class CustomerHierarchyStream(GoogleAdsStream):
     def post_process(self, row, context=None):
         row = super().post_process(row, context)
         customer = row["customerClient"]
+        customer_id = customer["id"]
+
+        # sync only customers we haven't seen
+        if customer_id in self.seen_customer_ids:
+            return None
+
+        self.seen_customer_ids.add(customer_id)
 
         if self.customer_ids and customer["id"] not in self.customer_ids:
             self.skipped_customer_ids[SkippedReason.NOT_IN_CONFIG].append(


### PR DESCRIPTION
After #121 was merged, we started seeing issues where we were missing data for some customers. This is because

> `customer_id(s)` now acts more like a traditional filter, rather than a hard override

so each given customer ID has to be

1. available in the customer hierarchy
2. a non-manager
3. enabled

in order to sync child streams.

The problem lies with point 1, in that the `customer_hierarchy` stream performs some filtering in the query to return customers up to (and including) `level` 1 only. In our case, the majority of the customers specified via config actually resolve as `level` 2, so were not returned by the query.

It is unclear why this `level` condition is present (existing since the stream was added near when the tap was created), but removing this *does* return customers that we expect to be able to filter by.

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/1fab76c2-e1c1-46b0-9fe9-014116f4c68d" />

N.B. this is a behavioural change for those using the tap without specifying `customer_id(s)`, in that more data may be synced.