### PR TITLE
fix: Enforce YYYY-MM-DD format for all dates in query conditions

### DIFF
--- a/tap_googleads/client.py
+++ b/tap_googleads/client.py
@@ -6,7 +6,6 @@ from http import HTTPStatus
 from typing import Any, Dict, Optional
 
 import requests
-
 from singer_sdk.authenticators import OAuthAuthenticator
 from singer_sdk.streams import RESTStream
 
@@ -154,7 +153,12 @@ class GoogleAdsStream(RESTStream):
 
     @cached_property
     def start_date(self):
-        return datetime.fromisoformat(self.config["start_date"]).strftime(r"'%Y-%m-%d'")
+        start_value = (
+            self.get_starting_replication_key_value(self.context)
+            or self.config["start_date"]
+        )
+
+        return datetime.fromisoformat(start_value).strftime(r"'%Y-%m-%d'")
 
     @cached_property
     def end_date(self):

--- a/tap_googleads/dynamic_query_stream.py
+++ b/tap_googleads/dynamic_query_stream.py
@@ -56,21 +56,16 @@ class DynamicQueryStream(ReportsStream):
         if hasattr(self, "_date_filter_applied") and self._date_filter_applied:
             return
 
-        start_date = self.get_starting_replication_key_value(context)
-        if not start_date:
-            start_date = self.start_date
-        else:
-            start_date = f"'{start_date}'"
         query = self.gaql
         if "WHERE" in query.upper():
             self.gaql = (
                 query.rstrip()
-                + f" AND segments.date >= {start_date} AND segments.date <= {self.end_date} ORDER BY segments.date ASC"
+                + f" AND segments.date >= {self.start_date} AND segments.date <= {self.end_date} ORDER BY segments.date ASC"
             )
         else:
             self.gaql = (
                 query.rstrip()
-                + f" WHERE segments.date >= {start_date} AND segments.date <= {self.end_date} ORDER BY segments.date ASC"
+                + f" WHERE segments.date >= {self.start_date} AND segments.date <= {self.end_date} ORDER BY segments.date ASC"
             )
 
         self._date_filter_applied = True


### PR DESCRIPTION
Fix for the following error caused by a date-time (rather than date-only) `start_date` value:

```console
singer_sdk.exceptions.FatalAPIError: 400 Client Error: Bad Request for path: /v20/customers/2030837398/googleAds:search. Error 400: Request contains an invalid argument. (INVALID_ARGUMENT)
Details: Dates in conditions should be in 'YYYY-MM-DD' format. Received: segments.date >= '2025-11-20T00:00'
```