### PR TITLE
fix: Bad property in `campaign_performance_by_location` primary key

### DIFF
--- a/tap_googleads/dynamic_streams/campaign_performance_by_location.py
+++ b/tap_googleads/dynamic_streams/campaign_performance_by_location.py
@@ -14,7 +14,7 @@ class CampaignPerformanceByLocation(DynamicQueryStream):
 
     name = "campaign_performance_by_location"
     primary_keys = [
-        "locationView_resourceName",
+        "locationView__resourceName",
         "campaign__name",
         "segments__date",
     ]


### PR DESCRIPTION
#96 updated the stream primary key to use `locationView_resourceName`, but missed out an underscore representing the nested property, as per the automatic flattening behaviour. This results in

```
psycopg2.errors.UndefinedColumn: column "location_view_resource_name" named in key does not exist
```

when loading into Postgres.