### PR TITLE
fix: Translate renamed properties when referencing older API versions

### DIFF
--- a/tap_googleads/dynamic_query_stream.py
+++ b/tap_googleads/dynamic_query_stream.py
@@ -150,7 +150,7 @@ class DynamicQueryStream(ReportsStream):
             "DOUBLE": "number",
         }
         try:
-            query_object = sqlparse.parse(self.gaql)[0]
+            query_object = sqlparse.parse(self.versioned_gaql)[0]
         except ValueError:
             message = f"The GAQL query {self.name} failed. Validate your GAQL query with the Google Ads query validator. https://developers.google.com/google-ads/api/fields/v22/query_validator"
             raise ValueError(message)


### PR DESCRIPTION
Another follow up to #127 (and #128), where allowing configuration of the API version was somewhat redundant as the built-in stream queries were updated in line with `v22` - these were then not longer compatible with any other currently available API version (e.g. `v21`):

```console
2025-12-09 16:29:07,657 | ERROR    | tap-googleads.campaign_budget | Unrecognised fields: ['metrics.trueview_average_cpv', 'metrics.video_trueview_view_rate', 'metrics.video_trueview_views']
2025-12-09 16:29:07,657 | ERROR    | tap-googleads.campaign_budget | Check Google Ads API version changes here: https://developers.google.com/google-ads/api/docs/upgrade
```

This change updates the tap to catalog and apply renames across currently available API versions.